### PR TITLE
added `vsprintf_like` rules

### DIFF
--- a/vulfi_prototypes.json
+++ b/vulfi_prototypes.json
@@ -316,6 +316,7 @@
     ".vsprintf_l":"int vsprintf_l(char* buffer, char* format, void* locale, va_list argptr);",
     "_vsprintf_l":"int vsprintf_l(char* buffer, char* format, void* locale, va_list argptr);",
     "vsprintf_l":"int vsprintf_l(char* buffer, char* format, void* locale, va_list argptr);",
+    "vsprintf_like":"int vsprintf_like(char* buffer, char* format, va_list argptr);",
     ".vsprintf_p":"int _vsprintf_p(char *buffer, int sizeInBytes, char* format, va_list argptr);",
     "_vsprintf_p":"int _vsprintf_p(char *buffer, int sizeInBytes, char* format, va_list argptr);",
     "vsprintf_p":"int _vsprintf_p(char *buffer, int sizeInBytes, char* format, va_list argptr);",

--- a/vulfi_rules.json
+++ b/vulfi_rules.json
@@ -81,6 +81,7 @@
             "vfscanf_s",
             "vfwscanf_s",
             "vsprintf_l",
+            "vsprintf_like",
             "vswprintf",
             "vsprintf_s",
             "vswprintf_s",
@@ -274,7 +275,8 @@
             "fscanf",
             "sscanf",
             "sprintf",
-            "vsprintf"
+            "vsprintf",
+            "vsprintf_like"
         ],
         "wrappers":false,
         "mark_if":{


### PR DESCRIPTION
sometimes IDA will utilize the `vsprintf_like` syntax to mark functions. This rules will "capture" this specific case